### PR TITLE
Create proxy for lite mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ $ git clone git@github.com:m4mController/frontend.git && cd frontend
 * `SERVER`. **Ignored with `npm run build`!** Default: `backend`. Possible values:
   * `backend`: frontend will be targeted to the real backend (meter4.me). 
   * `proxy`: local proxy server to the backend will be started. Good for local deploying.
-  * `mock`: local mock server will be started. Good for local lite frontend version deploying.
+  * `mock`: local mock server will be started. Good for deploying without internet access.
 * `MODE`. Default: `default`. Possible values:
   * `default`: frontend for meter4.me will be build.
   * `lite`: frontend for controller will be build.
+* `BACKEND_API`. Backend 
   
 Now you can build and run the app, there are several ways to do it:
 

--- a/app/constants.js
+++ b/app/constants.js
@@ -4,26 +4,10 @@ const appConfig = config.APP;
 
 export const IS_DEV = appConfig.environment === 'development';
 
-export const IS_LITE_MODE = appConfig.isLiteMode || !appConfig.backend;
+export const IS_LITE_MODE = appConfig.isLiteMode;
 
-export const BACKEND_API = function() {
-  if (IS_LITE_MODE) {
-    return '/api';
-  } else if (appConfig.isUsingProxy) {
-    return '/api/api';
-  } else {
-    return appConfig.backend.api;
-  }
-}();
+export const BACKEND_API = appConfig.backend.api;
 
-export const BACKEND_AUTH = function() {
-  if (IS_LITE_MODE) {
-    return null;
-  } else if (appConfig.isUsingProxy) {
-    return '/api/auth';
-  } else {
-    return appConfig.backend.auth;
-  }
-}();
+export const BACKEND_AUTH = appConfig.backend.auth;
 
 export const GRID_STEP = 8;

--- a/config/environment.js
+++ b/config/environment.js
@@ -26,8 +26,8 @@ module.exports = function(environment) {
       isLiteMode: LITE_MODE,
       isUsingProxy: USE_PROXY,
       backend: {
-        api: 'https://api.meter4.me',
-        auth: 'https://auth.meter4.me',
+        api: null, // эти переменные определены далее в конфиге
+        auth: null,
       },
     },
     'ember-google-maps': {
@@ -39,6 +39,28 @@ module.exports = function(environment) {
       libraries: ['geometry', 'places'],
     },
   };
+
+  if (USE_PROXY) {
+    if (LITE_MODE) {
+      ENV.APP.backend.api = '/api';
+    } else {
+      ENV.APP.backend.api = '/api/api';
+      ENV.APP.backend.auth = '/api/auth';
+    }
+
+    // чтобы дать серверу-проксировщику знать, куда проксировать запрос
+    ENV.APP.proxy = {
+      api: process.env['BACKEND_API'] || 'https://api.meter4.me',
+      auth: process.env['BACKEND_AUTH'] || 'https://auth.meter4.me',
+    };
+  } else {
+    if (LITE_MODE) {
+      ENV.APP.backend.api = process.env['BACKEND_API'] || '/api';
+    } else {
+      ENV.APP.backend.api = process.env['BACKEND_API'] || 'https://api.meter4.me';
+      ENV.APP.backend.auth = process.env['BACKEND_AUTH'] || 'https://auth.meter4.me';
+    }
+  }
 
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;

--- a/server/index.js
+++ b/server/index.js
@@ -14,7 +14,6 @@ module.exports = function(app) {
   const modules = [];
   switch (serverMode) {
     case 'proxy':
-      if (mode === 'lite') throw 'Proxy is not implemented for lite mode';
       const proxies = globSync(`./proxies/${mode}/*.js`, {cwd: __dirname}).map(require);
       modules.push(...proxies);
       break;

--- a/server/proxies/default/auth.js
+++ b/server/proxies/default/auth.js
@@ -2,8 +2,8 @@
 
 const config = require('../../../config/environment')();
 
-const proxyPath = '/api/auth';
-const target = config.APP.backend.auth;
+const proxyPath = config.APP.backend.auth;
+const target = config.APP.proxy.auth;
 
 module.exports = function(app) {
   // For options, see:

--- a/server/proxies/lite/api.js
+++ b/server/proxies/lite/api.js
@@ -5,6 +5,7 @@ const config = require('../../../config/environment')();
 const proxyPath = config.APP.backend.api;
 const target = config.APP.proxy.api;
 
+console.log(target);
 module.exports = function(app) {
   // For options, see:
   // https://github.com/nodejitsu/node-http-proxy
@@ -14,6 +15,7 @@ module.exports = function(app) {
   });
 
   proxy.on('error', function(err, req) {
+    console.error(target);
     console.error(err, req.url);
   });
 


### PR DESCRIPTION
теперь можно локально тестировать вот так:

поднимет локальный бекенд:
```bash
git clone https://github.com/M4MController/controller-deploy.git
cd controller-deploy
cp docker-compose.local.no-xbee.yml docker-compose.yml
docker-compose up -d backend
```

чтобы включить автогенерацию данных (имитация сбора данных с авто)
```bash
docker-compose up -d sensor_obd_gps
```

чтобы включить подписывание данных (имитация радиомодуля xbee). _оно будет сильно нагружать cpu_
```bash
docker-compose up -d signifier
```

запускать локальный фронтенд вот так:
```bash
MODE=lite BACKEND_API=http://localhost:5000 SERVER=proxy npm start
```